### PR TITLE
Modification d'un bug d'update pour les posts

### DIFF
--- a/src/App/Admin/Controller/PostController.php
+++ b/src/App/Admin/Controller/PostController.php
@@ -118,6 +118,7 @@ class PostController extends Controller implements ControllerInterface
             $form->select('user', $usersSelect, $posts['user'], 'Auteur de l\'article');
         } else {
             $form->item("<p>Auteur : {$post->getUser()}</p>");
+            $form->input('user', '', $post->getUser(), 'hidden');
         }
 
         $form = $form->submit('Valider');

--- a/src/Core/Form/Form.php
+++ b/src/Core/Form/Form.php
@@ -58,7 +58,11 @@ class Form implements FormInterface
     ): void {
         $label = $this->labelConstruct($name, $label);
 
-        $this->form .= "<label for='{$name}'>{$label}</label>" .
+        if ($type !== 'hidden') {
+            $this->form .= "<label for='{$name}'>{$label}</label>";
+        }
+
+        $this->form .=
             '<input
                 type="' . $type . '"
                 id="' . $name . '"


### PR DESCRIPTION
Les "Auteurs" ne pouvaient pas modifier les articles à cause de la sécurité qui vérifie si tous les champs sont remplis. Comme les auteurs ne peuvent pas modifier l'auteur de l'article, ce dernier champ n'était pas renseigné et l'update ne se faisait pas.
Création d'un input caché pour résoudre le problème.